### PR TITLE
Fix the "Unresolved specs" warning

### DIFF
--- a/nyan-cat-formatter.gemspec
+++ b/nyan-cat-formatter.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "rspec", ">= 2.14.2", ">= 2.99", "< 4"
+  s.add_dependency "rspec", ">= 2.14.2", "< 4"
 
   s.add_development_dependency "rake"
 end


### PR DESCRIPTION
The original `rspec` version dependency specifier causes the following warning message when launching specs:

```
WARN: Unresolved specs during Gem::Specification.reset:
      rspec (< 4, >= 2.14.2, >= 2.99)
WARN: Clearing out unresolved specs.
```

It is also look (for me at least)  a little bit contradicting to itself, so I've just cut to `">= 2.14.2", "4"`.