### PR TITLE
Change Fixnum to Integer

### DIFF
--- a/lib/nyan_cat_formatter/rspec3.rb
+++ b/lib/nyan_cat_formatter/rspec3.rb
@@ -17,7 +17,7 @@ class RSpec3 < RSpec::Core::Formatters::BaseTextFormatter
 
   def start(notification)
     # TODO: Lazy fix for specs.
-    if notification.kind_of?(Fixnum)
+    if notification.kind_of?(Integer)
       super(OpenStruct.new(:count => notification))
     else
       super(notification)


### PR DESCRIPTION
Fixnum is deprecated in Ruby 2.4