### PR TITLE
Scoreboard colors

### DIFF
--- a/lib/nyan_cat_formatter/common.rb
+++ b/lib/nyan_cat_formatter/common.rb
@@ -9,8 +9,7 @@ module NyanCat
     ERROR    = '!'
     PENDING  = '+'
 
-    VT100_CODES =
-      {
+    VT100_CODES = {
       :black   => 30,
       :red     => 31,
       :green   => 32,
@@ -21,8 +20,6 @@ module NyanCat
       :white   => 37,
       :bold    => 1,
     }
-
-    VT100_CODE_VALUES = VT100_CODES.invert
 
     def self.included(base)
       base.class_eval do
@@ -241,19 +238,13 @@ module NyanCat
       wrap(text, :red)
     end
 
-    def console_code_for(code_or_symbol)
-      if VT100_CODE_VALUES.has_key?(code_or_symbol)
-        code_or_symbol
-      else
-        VT100_CODES.fetch(code_or_symbol) do
-          console_code_for(:white)
-        end
-      end
+    def console_color_code_for(symbol)
+      VT100_CODES[symbol] || VT100_CODES.fetch(:white)
     end
 
-    def wrap(text, code_or_symbol)
+    def wrap(text, symbol)
       if RSpec.configuration.color_enabled?
-        "\e[#{console_code_for(code_or_symbol)}m#{text}\e[0m"
+        "\e[#{console_color_code_for(symbol)}m#{text}\e[0m"
       else
         text
       end

--- a/lib/nyan_cat_formatter/common.rb
+++ b/lib/nyan_cat_formatter/common.rb
@@ -230,15 +230,15 @@ module NyanCat
     end
 
     def success_color(text)
-      wrap(text, :success)
+      wrap(text, :green)
     end
 
     def pending_color(text)
-      wrap(text, :pending)
+      wrap(text, :yellow)
     end
 
     def failure_color(text)
-      wrap(text, :failure)
+      wrap(text, :red)
     end
 
     def console_code_for(code_or_symbol)

--- a/spec/nyan_cat_formatter_spec.rb
+++ b/spec/nyan_cat_formatter_spec.rb
@@ -50,6 +50,30 @@ describe NyanCatFormatter do
       end
     end
 
+    describe 'colors' do
+      before do
+        allow(RSpec.configuration).to receive(:color_enabled?).and_return(true)
+        @success_index = 1
+        @pending_index = 2
+        @failure_index = 3
+        @success_color_escape_string = "\e[32" # green
+        @pending_color_escape_string = "\e[33" # yellow
+        @failure_color_escape_string = "\e[31" # red
+      end
+
+      it 'should wrap success score in success color' do
+        expect(@formatter.scoreboard[@success_index][0..3]).to eq(@success_color_escape_string)
+      end
+
+      it 'should wrap pending score in pending color' do
+        expect(@formatter.scoreboard[@pending_index][0..3]).to eq(@pending_color_escape_string)
+      end
+
+      it 'should wrap failure score in failure color' do
+        expect(@formatter.scoreboard[@failure_index][0..3]).to eq(@failure_color_escape_string)
+      end
+    end
+
     describe 'example_pending' do
       it_behaves_like 'a test'
 


### PR DESCRIPTION
I noticed a bug. The `wrap` method was being sent `:success`, `:pending`, and `:failure` keys. Since those keys don't exist in the `VT100_CODES` hash, all the scoreboard values were displaying in the default white.

I also simplified the logic for fetching color codes because I noticed the following two issues:
1. The recursive call `console_code_for(:white)` will result in infinite recursion if the `:white` key doesn't exist in the `VT100_CODES` hash.
2. The `console_code_for` method had logic to allow the caller to send the actual color code instead of a symbol. However, I cannot find any place where a color code is sent to that method, so the added complexity of that logic seemed unnecessary.